### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl"        : "6.*",
     "name"        : "Yapsi",
+    "license"     : "Artistic-2.0",
     "version"     : "2011.02",
     "description" : "A Perl 6 compiler-and-runtime written in Perl 6",
     "provides"    : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license